### PR TITLE
chore: bump the version

### DIFF
--- a/transition-scripts/values/values.yaml
+++ b/transition-scripts/values/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/bcgov/sso
-  tag: 7.6.5-build.25
+  tag: 7.6.5-build.26
   pullPolicy: IfNotPresent
 
 additionalServerOptions: "-Dkeycloak.profile.feature.impersonation=disabled -Djboss.persistent.log.dir=/var/log/eap"


### PR DESCRIPTION
When this get's merged to dev, we can roll out the latest keycloak image in sandbox, for prod we need to create a pr to main