### PR TITLE
chore: redirect the xlog to sso-alerts channel

### DIFF
--- a/.github/workflows/xlog-cron-compare.yml
+++ b/.github/workflows/xlog-cron-compare.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           type: ${{ job.status }}
           job_name: '*One of the production xlogs failed to synch*'
-          mention: 'jsharman nithinshekar.kuruba Marco'
+          mention: 'jsharman @nithinshekar.kuruba @Marco'
           mention_if: 'failure'
           channel: '#sso-alerts'
           url: ${{ secrets.SSO_ALERTS }}

--- a/.github/workflows/xlog-cron-compare.yml
+++ b/.github/workflows/xlog-cron-compare.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           type: ${{ job.status }}
           job_name: '*One of the production xlogs failed to synch*'
-          mention: 'jsharman'
+          mention: 'jsharman nithinshekar.kuruba Marco'
           mention_if: 'failure'
-          channel: '#jsharman-alert-test'
-          url: ${{ secrets.JON_SSO_ALERTS }}
-          token: ${{ secrets.JON_ROCKETCHAT_TOKEN }}
+          channel: '#sso-alerts'
+          url: ${{ secrets.SSO_ALERTS }}
+          token: ${{ secrets.ROCKETCHAT_TOKEN }}

--- a/transition-scripts/helpers/patroni.sh
+++ b/transition-scripts/helpers/patroni.sh
@@ -269,8 +269,7 @@ wait_for_patroni_xlog_close() {
     fi
 
     # Retry for 100 seconds before failing
-    # increase to 20 on final PR
-    if [[ "$count" -gt 2 ]]; then
+    if [[ "$count" -gt 20 ]]; then
       warn "patroni xlog in $namespace failed to be synced"
       # trigger the alert
       exit 1

--- a/transition-scripts/helpers/patroni.sh
+++ b/transition-scripts/helpers/patroni.sh
@@ -269,7 +269,8 @@ wait_for_patroni_xlog_close() {
     fi
 
     # Retry for 100 seconds before failing
-    if [[ "$count" -gt 20 ]]; then
+    # increase to 20 on final PR
+    if [[ "$count" -gt 2 ]]; then
       warn "patroni xlog in $namespace failed to be synced"
       # trigger the alert
       exit 1

--- a/transition-scripts/xlog-comparison.sh
+++ b/transition-scripts/xlog-comparison.sh
@@ -13,7 +13,6 @@ Usages:
     $0
 
 Available namespaces:
-    - c6af30-dev
     - eb75ad-dev
     - eb75ad-test
     - eb75ad-prod
@@ -24,7 +23,7 @@ EOF
 pwd="$(dirname "$0")"
 source "$pwd/helpers/_all.sh"
 
-namespaces=(c6af30-dev eb75ad-dev eb75ad-test eb75ad-prod)
+namespaces=(eb75ad-dev eb75ad-test eb75ad-prod)
 
 for namespace in "${namespaces[@]}"
 do

--- a/transition-scripts/xlog-comparison.sh
+++ b/transition-scripts/xlog-comparison.sh
@@ -24,7 +24,7 @@ EOF
 pwd="$(dirname "$0")"
 source "$pwd/helpers/_all.sh"
 
-namespaces=(eb75ad-dev eb75ad-test eb75ad-prod)
+namespaces=(c6af30-dev eb75ad-dev eb75ad-test eb75ad-prod)
 
 for namespace in "${namespaces[@]}"
 do


### PR DESCRIPTION
This will point the xlog alert at the sso-alerts channel and ping the ops team when the hourly cron job fails.