### PR TITLE
fix: set explicit request and limits on patroni containers

### DIFF
--- a/transition-scripts/values/values.yaml
+++ b/transition-scripts/values/values.yaml
@@ -41,3 +41,12 @@ readinessProbe:
 rollingUpdate:
   maxSurge: "100%"
   maxUnavailable: 0
+
+patroni:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1.5Gi
+    requests:
+      cpu: 50m
+      memory: 300Mi


### PR DESCRIPTION
[sso-team-711](https://bcdevex.atlassian.net/jira/software/projects/SSOTEAM/boards/39?selectedIssue=SSOTEAM-711)
The cluster defaults appear to be:
```
request:
  cpu: 0.05
  memory: 264.44M
limit
  cpu: 0.25
  memory: 1.07G
```
Inspected using sysdig.  I used this reference when setting the explicit size limit and request to bigger than we had