### PR TITLE
fix: use version instead of whole tag for sandbox deploy

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -87,7 +87,7 @@ jobs:
       - id: get-tag
         name: Get Tag
         run: |
-          echo "release_tag=${{ endsWith(github.ref, '/main') && steps.release.outputs.tag_name || steps.meta.outputs.tags}}" >> $GITHUB_OUTPUT
+          echo "release_tag=${{ endsWith(github.ref, '/main') && steps.release.outputs.tag_name || steps.meta.outputs.version }}" >> $GITHUB_OUTPUT
 
   deploy-to-openshift:
     needs: [build-and-push-image]


### PR DESCRIPTION
Fixes [SSOTEAM-280](https://bcdevex.atlassian.net/browse/SSOTEAM-280)

[SSOTEAM-280]: https://bcdevex.atlassian.net/browse/SSOTEAM-280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ