### PR TITLE
feat: keepalive action

### DIFF
--- a/.github/workflows/xlog-cron-compare.yml
+++ b/.github/workflows/xlog-cron-compare.yml
@@ -37,3 +37,11 @@ jobs:
           channel: '#sso-alerts'
           url: ${{ secrets.SSO_ALERTS }}
           token: ${{ secrets.ROCKETCHAT_TOKEN }}
+  keepalive:
+    name: Keepalive Workflow
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@6112edb887975f902d74a6a66b688aed71932a70


### PR DESCRIPTION
Use the keepalive github action so that the cronjob for xlogs comparison doesn't idle after 60 days with no commits. I locked the action to the commit hash so it can't change on us, since it needs action write permission