### PR TITLE
chore: override logging

### DIFF
--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -10,6 +10,7 @@ RUN apk add --no-cache \
         curl \
         gcc \
         libressl-dev \
+        openssl-dev \
         musl-dev \
         libffi-dev && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal && \
@@ -20,7 +21,8 @@ RUN apk add --no-cache \
         gcc \
         libressl-dev \
         musl-dev \
-        libffi-dev
+        libffi-dev \
+        openssl-dev
 
 COPY ./pyproject.toml .
 COPY ./poetry.lock .

--- a/transition-scripts/values/e4ca1d/dev/values-gold-e4ca1d-dev-active.yaml
+++ b/transition-scripts/values/e4ca1d/dev/values-gold-e4ca1d-dev-active.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-dev.apps.gold.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/dev/values-gold-e4ca1d-dev-standby.yaml
+++ b/transition-scripts/values/e4ca1d/dev/values-gold-e4ca1d-dev-standby.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-dev.apps.gold.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/dev/values-golddr-e4ca1d-dev-active.yaml
+++ b/transition-scripts/values/e4ca1d/dev/values-golddr-e4ca1d-dev-active.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-dev.apps.golddr.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/dev/values-golddr-e4ca1d-dev-standby.yaml
+++ b/transition-scripts/values/e4ca1d/dev/values-golddr-e4ca1d-dev-standby.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://dev.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-dev.apps.golddr.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/prod/values-gold-e4ca1d-prod-active.yaml
+++ b/transition-scripts/values/e4ca1d/prod/values-gold-e4ca1d-prod-active.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-prod.apps.gold.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/prod/values-gold-e4ca1d-prod-standby.yaml
+++ b/transition-scripts/values/e4ca1d/prod/values-gold-e4ca1d-prod-standby.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-prod.apps.gold.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/prod/values-golddr-e4ca1d-prod-active.yaml
+++ b/transition-scripts/values/e4ca1d/prod/values-golddr-e4ca1d-prod-active.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-prod.apps.golddr.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/prod/values-golddr-e4ca1d-prod-standby.yaml
+++ b/transition-scripts/values/e4ca1d/prod/values-golddr-e4ca1d-prod-standby.yaml
@@ -8,6 +8,17 @@ additionalServerOptions: >-
   -Djboss.persistent.log.dir=/var/log/eap
   -Djgroups.dns.query=sso-keycloak-ping.e4ca1d-dev.svc.cluster.local
 
+extraEnvs:
+  - name: KC_HOSTNAME_URL
+    value: https://sandbox.loginproxy.gov.bc.ca/auth/
+  - name: KC_HOSTNAME_ADMIN_URL
+    value: https://sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
 
 replicaCount: 0
 

--- a/transition-scripts/values/e4ca1d/test/values-gold-e4ca1d-test-active.yaml
+++ b/transition-scripts/values/e4ca1d/test/values-gold-e4ca1d-test-active.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-test.apps.gold.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/test/values-gold-e4ca1d-test-standby.yaml
+++ b/transition-scripts/values/e4ca1d/test/values-gold-e4ca1d-test-standby.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-test.apps.gold.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/test/values-golddr-e4ca1d-test-active.yaml
+++ b/transition-scripts/values/e4ca1d/test/values-golddr-e4ca1d-test-active.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-test.apps.golddr.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/e4ca1d/test/values-golddr-e4ca1d-test-standby.yaml
+++ b/transition-scripts/values/e4ca1d/test/values-golddr-e4ca1d-test-standby.yaml
@@ -10,6 +10,12 @@ extraEnvs:
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
   - name: KC_HOSTNAME_ADMIN_URL
     value: https://test.sandbox.loginproxy.gov.bc.ca/auth/
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_BACKUP_INDEX
+    value: 42
+  - name: QUARKUS_LOG_FILE_ROTATION_MAX_FILE_SIZE
+    value: 1M
+  - name: QUARKUS_LOG_FILE_ROTATION_FILE_SUFFIX
+    value: .zip
   ## If debugging needs to be done without the use of the vanity urls, use the following KC_HOSTNAMES
   # - name: KC_HOSTNAME_URL
   #   value: https://sso-keycloak-e4ca1d-test.apps.golddr.devops.gov.bc.ca/auth/

--- a/transition-scripts/values/values.yaml
+++ b/transition-scripts/values/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/bcgov/sso
-  tag: 24.0.5-build.1
+  tag: 24.0.6-build.1
   pullPolicy: Always
 
 additionalServerOptions: "-Dkeycloak.profile.feature.impersonation=disabled -Djboss.persistent.log.dir=/var/log/eap"


### PR DESCRIPTION
Adding overrides for log configuration in sandbox, the default in the new image is large for production. Also bumping the image to 24.0.6, this image is already pushed and in sandbox